### PR TITLE
merge: staging to main

### DIFF
--- a/lib/sections/experience/presentation/experience.dart
+++ b/lib/sections/experience/presentation/experience.dart
@@ -18,6 +18,13 @@ class ExperienceSection extends StatelessWidget {
           Text("Work Experience", style: poppinsH3),
           SizedBox(height: 10),
           ExperienceCard(
+            company: 'HomesFarmsandLand LLC',
+            position: 'Software Engineer',
+            duration: 'August 2025 - Present',
+            description:
+                "I design automation workflows and create internal software tools across desktop and mobile platforms to streamline processes and improve productivity.",
+          ),
+          ExperienceCard(
             company: 'Reelist8',
             position: 'Mobile Developer',
             duration: 'May 2025 - August 2025',


### PR DESCRIPTION
This pull request adds a new work experience entry to the `ExperienceSection` in the user interface. The new entry details a Software Engineer position at HomesFarmsandLand LLC and appears above the existing experience cards.

UI content update:

* Added a new `ExperienceCard` for the role of Software Engineer at HomesFarmsandLand LLC, including company name, position, duration, and a brief description of responsibilities. (`lib/sections/experience/presentation/experience.dart`)