### PR TITLE
chore: add experience in desktop view

### DIFF
--- a/lib/sections/experience/presentation/experience.dart
+++ b/lib/sections/experience/presentation/experience.dart
@@ -85,6 +85,13 @@ class ExperienceSection extends StatelessWidget {
                   Text("Work Experience", style: poppinsH3),
                   SizedBox(height: 10),
                   ExperienceCard(
+                    company: 'HomesFarmsandLand LLC',
+                    position: 'Software Engineer',
+                    duration: 'August 2025 - Present',
+                    description:
+                        "I design automation workflows and create internal software tools across desktop and mobile platforms to streamline processes and improve productivity.",
+                  ),
+                  ExperienceCard(
                     company: 'Reelist8',
                     position: 'Mobile Developer',
                     duration: 'May 2025 - August 2025',


### PR DESCRIPTION
This pull request adds a new work experience entry to the `ExperienceSection` in the `experience.dart` file. The update introduces an `ExperienceCard` for a Software Engineer position at HomesFarmsandLand LLC, including details about the role and responsibilities.

* Added an `ExperienceCard` for 'HomesFarmsandLand LLC' as a Software Engineer, detailing the position, duration, and a brief description of the work.